### PR TITLE
Migrate to java 17

### DIFF
--- a/sakila-address-service/Dockerfile
+++ b/sakila-address-service/Dockerfile
@@ -1,8 +1,32 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:17.0.6-alpine3.17 as jdk-builder
 
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/sakila-address-service/sakila-address-service.jar"]
+RUN apk add --no-cache binutils
 
-COPY target/lib           /usr/share/sakila-address-service/lib
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules java.base,java.compiler,java.desktop,java.instrument,java.management,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql.rowset,jdk.httpserver,jdk.jdi,jdk.jfr,jdk.unsupported \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM alpine:3.17
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jdk-builder /jre $JAVA_HOME
+
+RUN adduser --no-create-home -u 1000 -D service
+
+RUN mkdir /usr/share/sakila-address-service && \
+    chown -R service /usr/share/sakila-address-service
+
+USER 1000
+
+COPY --chown=1000:1000 target/lib /usr/share/sakila-address-service/lib
 
 ARG JAR_FILE
-COPY target/${JAR_FILE} /usr/share/sakila-address-service/sakila-address-service.jar
+COPY --chown=1000:1000 target/${JAR_FILE} /usr/share/sakila-address-service/sakila-address-service.jar
+
+ENTRYPOINT ["/jre/bin/java", "-jar", "/usr/share/sakila-address-service/sakila-address-service.jar"]

--- a/sakila-address-service/pom.xml
+++ b/sakila-address-service/pom.xml
@@ -13,22 +13,21 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-    <spring.boot.starter.version>2.2.0.RELEASE</spring.boot.starter.version>
-    <spring-orm.version>5.2.0.RELEASE</spring-orm.version>
-    <spring-kafka.version>2.4.5.RELEASE</spring-kafka.version>
-    <spring-cloud-dependencies.version>Hoxton.RELEASE</spring-cloud-dependencies.version>
-    <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
+    <java.version>17</java.version>
+    <spring.boot.starter.version>2.7.8</spring.boot.starter.version>
+    <spring-kafka.version>3.0.2</spring-kafka.version>
+    <spring-cloud-dependencies.version>2021.0.5</spring-cloud-dependencies.version>
+    <spring-boot-maven-plugin.version>2.7.8</spring-boot-maven-plugin.version>
     <flyway.version>5.2.3</flyway.version>
     <postgres.version>42.2.8</postgres.version>
     <hibernate-types-52.version>2.4.0</hibernate-types-52.version>
     <swagger-annotations.version>1.5.17</swagger-annotations.version>
     <springfox-swagger2.version>2.7.0</springfox-swagger2.version>
-    <jackson.core.version>2.10.0</jackson.core.version>
-    <gson.version>2.8.6</gson.version>
-    <groovy.version>2.5.11</groovy.version>
-    <spock.version>1.3-groovy-2.5</spock.version>
-    <swagger-codegen.version>2.4.0</swagger-codegen.version>
+    <jackson.core.version>2.13.4</jackson.core.version>
+    <gson.version>2.10.1</gson.version>
+    <groovy.version>4.0.7</groovy.version>
+    <spock.version> 2.4-M1-groovy-4.0</spock.version>
+    <swagger-codegen.version>2.4.29</swagger-codegen.version>
     <sakila-address-api-spec.version>1.0-SNAPSHOT</sakila-address-api-spec.version>
     <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
@@ -53,6 +52,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+      <version>${spring.boot.starter.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
       <version>${flyway.version}</version>
@@ -62,12 +67,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
       <version>${spring.boot.starter.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-orm</artifactId>
-      <version>${spring-orm.version}</version>
     </dependency>
 
     <dependency>
@@ -115,20 +114,38 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-      <version>${spring.boot.starter.version}</version>
+      <version>3.1.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-      <version>${spring-kafka.version}</version>
+      <version>2.9.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-all</artifactId>
       <version>${groovy.version}</version>
       <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.3</version>
     </dependency>
 
     <dependency>

--- a/sakila-address-service/src/main/java/com/example/sakila/config/CorsConfig.groovy
+++ b/sakila-address-service/src/main/java/com/example/sakila/config/CorsConfig.groovy
@@ -13,7 +13,10 @@ class CorsConfig {
     return new WebMvcConfigurer() {
       @Override
       void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping('/**').allowedMethods('*')
+        registry.addMapping('/**')
+            .allowedOrigins('*')
+            .allowedHeaders('*')
+            .allowedMethods('*')
       }
     }
   }

--- a/sakila-api-gateway/Dockerfile
+++ b/sakila-api-gateway/Dockerfile
@@ -1,8 +1,32 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:17.0.6-alpine3.17 as jdk-builder
 
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/sakila-api-gateway/sakila-api-gateway.jar"]
+RUN apk add --no-cache binutils
 
-COPY target/lib           /usr/share/sakila-api-gateway/lib
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules java.base,java.desktop,java.instrument,java.management,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.sql,jdk.httpserver,jdk.jfr,jdk.unsupported \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM alpine:3.17
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jdk-builder /jre $JAVA_HOME
+
+RUN adduser --no-create-home -u 1000 -D service
+
+RUN mkdir /usr/share/sakila-api-gateway && \
+    chown -R service /usr/share/sakila-api-gateway
+
+USER 1000
+
+COPY --chown=1000:1000 target/lib /usr/share/sakila-api-gateway/lib
 
 ARG JAR_FILE
-COPY target/${JAR_FILE} /usr/share/sakila-api-gateway/sakila-api-gateway.jar
+COPY --chown=1000:1000 target/${JAR_FILE} /usr/share/sakila-api-gateway/sakila-api-gateway.jar
+
+ENTRYPOINT ["/jre/bin/java", "-jar", "/usr/share/sakila-api-gateway/sakila-api-gateway.jar"]

--- a/sakila-api-gateway/pom.xml
+++ b/sakila-api-gateway/pom.xml
@@ -19,13 +19,13 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-gateway</artifactId>
-      <version>2.2.0.RELEASE</version>
+      <version>3.1.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-      <version>2.2.0.RELEASE</version>
+      <version>3.1.4</version>
     </dependency>
 
     <dependency>
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>Hoxton.RELEASE</version>
+        <version>2021.0.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -109,8 +109,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>

--- a/sakila-api-gateway/src/main/resources/application.yml
+++ b/sakila-api-gateway/src/main/resources/application.yml
@@ -5,6 +5,14 @@ spring:
     name: sakila-api-gateway
   cloud:
     gateway:
+      default-filters:
+        - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials, RETAIN_UNIQUE
+      globalcors:
+        corsConfigurations:
+          '[/**]':
+            allowedOrigins: "*"
+            allowedHeaders: "*"
+            allowedMethods: "*"
       discovery:
         locator:
           lowerCaseServiceId: true

--- a/sakila-discovery-service/Dockerfile
+++ b/sakila-discovery-service/Dockerfile
@@ -1,8 +1,32 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:17.0.6-alpine3.17 as jdk-builder
 
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/sakila-discovery-server/sakila-discovery-server.jar"]
+RUN apk add --no-cache binutils
 
-COPY target/lib           /usr/share/sakila-discovery-server/lib
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules java.base,java.desktop,java.instrument,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.sql,jdk.httpserver,jdk.jfr,jdk.management,jdk.unsupported \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM alpine:3.17
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jdk-builder /jre $JAVA_HOME
+
+RUN adduser --no-create-home -u 1000 -D service
+
+RUN mkdir /usr/share/sakila-discovery-service && \
+    chown -R service /usr/share/sakila-discovery-service
+
+USER 1000
+
+COPY --chown=1000:1000 target/lib /usr/share/sakila-discovery-service/lib
 
 ARG JAR_FILE
-COPY target/${JAR_FILE} /usr/share/sakila-discovery-server/sakila-discovery-server.jar
+COPY --chown=1000:1000 target/${JAR_FILE} /usr/share/sakila-discovery-service/sakila-discovery-service.jar
+
+ENTRYPOINT ["/jre/bin/java", "-jar", "/usr/share/sakila-discovery-service/sakila-discovery-service.jar"]

--- a/sakila-discovery-service/pom.xml
+++ b/sakila-discovery-service/pom.xml
@@ -19,20 +19,20 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
-      <version>2.2.0.RELEASE</version>
+      <version>3.1.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>2.2.0.RELEASE</version>
+      <version>2.7.8</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.10.0</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-json</artifactId>
+      <version>2.7.8</version>
     </dependency>
 
     <dependency>
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>Hoxton.RELEASE</version>
+        <version>2021.0.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -114,15 +114,15 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.2.0.RELEASE</version>
+        <version>2.7.8</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>

--- a/sakila-film-service/Dockerfile
+++ b/sakila-film-service/Dockerfile
@@ -1,8 +1,32 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:17.0.6-alpine3.17 as jdk-builder
 
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/sakila-film-service/sakila-film-service.jar"]
+RUN apk add --no-cache binutils
 
-COPY target/lib           /usr/share/sakila-film-service/lib
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules java.base,java.desktop,java.instrument,java.management,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql.rowset,jdk.httpserver,jdk.jdi,jdk.jfr,jdk.zipfs,jdk.unsupported \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM alpine:3.17
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jdk-builder /jre $JAVA_HOME
+
+RUN adduser --no-create-home -u 1000 -D service
+
+RUN mkdir /usr/share/sakila-film-service && \
+    chown -R service /usr/share/sakila-film-service
+
+USER 1000
+
+COPY --chown=1000:1000 target/lib /usr/share/sakila-film-service/lib
 
 ARG JAR_FILE
-COPY target/${JAR_FILE} /usr/share/sakila-film-service/sakila-film-service.jar
+COPY --chown=1000:1000 target/${JAR_FILE} /usr/share/sakila-film-service/sakila-film-service.jar
+
+ENTRYPOINT ["/jre/bin/java", "-jar", "/usr/share/sakila-film-service/sakila-film-service.jar"]

--- a/sakila-film-service/pom.xml
+++ b/sakila-film-service/pom.xml
@@ -13,18 +13,20 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-    <spring.boot.starter.version>2.2.0.RELEASE</spring.boot.starter.version>
-    <spring-orm.version>5.2.0.RELEASE</spring-orm.version>
-    <spring-kafka.version>2.4.5.RELEASE</spring-kafka.version>
-    <spring-cloud-dependencies.version>Hoxton.RELEASE</spring-cloud-dependencies.version>
-    <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
+    <java.version>17</java.version>
+    <spring.boot.starter.version>2.7.8</spring.boot.starter.version>
+    <spring-kafka.version>3.0.2</spring-kafka.version>
+    <spring-cloud-dependencies.version>2021.0.5</spring-cloud-dependencies.version>
+    <spring-boot-maven-plugin.version>2.7.8</spring-boot-maven-plugin.version>
+    <postgres.version>42.2.8</postgres.version>
+    <hibernate-types-52.version>2.4.0</hibernate-types-52.version>
     <swagger-annotations.version>1.5.17</swagger-annotations.version>
     <springfox-swagger2.version>2.7.0</springfox-swagger2.version>
-    <jackson.core.version>2.10.0</jackson.core.version>
-    <gson.version>2.8.6</gson.version>
-    <mongo-java-driver.version>3.12.2</mongo-java-driver.version>
-    <swagger-codegen.version>2.4.0</swagger-codegen.version>
+    <jackson.core.version>2.13.4</jackson.core.version>
+    <gson.version>2.10.1</gson.version>
+    <mongo-java-driver.version>3.12.11</mongo-java-driver.version>
+    <spock.version> 2.4-M1-groovy-4.0</spock.version>
+    <swagger-codegen.version>2.4.29</swagger-codegen.version>
     <sakila-film-api-spec.version>1.0-SNAPSHOT</sakila-film-api-spec.version>
     <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
@@ -43,6 +45,12 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+      <version>${spring.boot.starter.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <version>${spring.boot.starter.version}</version>
       <scope>test</scope>
@@ -52,12 +60,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
       <version>${spring.boot.starter.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-orm</artifactId>
-      <version>${spring-orm.version}</version>
     </dependency>
 
     <dependency>
@@ -75,7 +77,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-      <version>${spring.boot.starter.version}</version>
+      <version>3.1.4</version>
     </dependency>
 
     <dependency>
@@ -105,7 +107,13 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-      <version>${spring-kafka.version}</version>
+      <version>2.9.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/sakila-film-service/src/main/java/com/example/sakila/config/CorsConfig.java
+++ b/sakila-film-service/src/main/java/com/example/sakila/config/CorsConfig.java
@@ -13,7 +13,10 @@ public class CorsConfig {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedMethods("*");
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowedHeaders("*")
+            .allowedMethods("*");
       }
     };
   }

--- a/sakila-film-service/src/main/java/com/example/sakila/data/migration/mongodb/MongoDBMigrationLoader.java
+++ b/sakila-film-service/src/main/java/com/example/sakila/data/migration/mongodb/MongoDBMigrationLoader.java
@@ -8,8 +8,9 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.*;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -32,7 +33,9 @@ public class MongoDBMigrationLoader {
     URI uri = getClass().getResource(path).toURI();
 
     if (uri.getScheme().equals("jar")) {
-      FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+      Map<String, String> env = new HashMap<>();
+      env.put("create", "true");
+      FileSystem fileSystem = FileSystems.newFileSystem(uri, env);
       result = fileSystem.getPath(path);
     } else {
       result = Paths.get(uri);

--- a/sakila-film-service/src/main/resources/application.properties
+++ b/sakila-film-service/src/main/resources/application.properties
@@ -12,6 +12,7 @@ management.endpoints.web.base-path=/api
 server.servlet.context-path=/api/film/
 
 server.port=0
+spring.security.
 
 spring.application.name=sakila-film-service
 eureka.instance.instance-id=${spring.application.name}:${spring.instance.instance-id:${random.value}}

--- a/sakila-frontend/Dockerfile
+++ b/sakila-frontend/Dockerfile
@@ -7,10 +7,10 @@ RUN apk update && apk add --no-cache make git
 WORKDIR /app
 COPY package.json package-lock.json  /app/
 
-RUN cd /app && npm install
+RUN cd /app && NODE_OPTIONS="--openssl-legacy-provider --no-experimental-fetch"  npm install
 COPY --chown=root . /app
 
-RUN cd /app && npm run build
+RUN cd /app && NODE_OPTIONS="--openssl-legacy-provider --no-experimental-fetch" npm run build
 
 
 FROM nginx:alpine

--- a/sakila-payment-service/Dockerfile
+++ b/sakila-payment-service/Dockerfile
@@ -1,8 +1,33 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:17.0.6-alpine3.17 as jdk-builder
 
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/sakila-payment-service/sakila-payment-service.jar"]
+RUN apk add --no-cache binutils
 
-COPY target/lib           /usr/share/sakila-payment-service/lib
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules java.base,java.desktop,java.instrument,java.management,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql.rowset,jdk.httpserver,jdk.jfr,jdk.unsupported \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM alpine:3.17
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jdk-builder /jre $JAVA_HOME
+
+RUN adduser --no-create-home -u 1000 -D service
+
+RUN mkdir /usr/share/sakila-payment-service && \
+    chown -R service /usr/share/sakila-payment-service
+
+USER 1000
+
+COPY --chown=1000:1000 target/lib /usr/share/sakila-payment-service/lib
 
 ARG JAR_FILE
-COPY target/${JAR_FILE} /usr/share/sakila-payment-service/sakila-payment-service.jar
+COPY --chown=1000:1000 target/${JAR_FILE} /usr/share/sakila-payment-service/sakila-payment-service.jar
+
+ENTRYPOINT ["/jre/bin/java", "-jar", "/usr/share/sakila-payment-service/sakila-payment-service.jar"]
+

--- a/sakila-payment-service/pom.xml
+++ b/sakila-payment-service/pom.xml
@@ -12,25 +12,22 @@
   <artifactId>sakila-payment-service</artifactId>
 
   <properties>
-    <kotlin.version>1.3.72</kotlin.version>
-    <kotlinx-coroutines-core.version>1.3.5</kotlinx-coroutines-core.version>
+    <kotlin.version>1.7.20</kotlin.version>
+    <kotlinx-coroutines-core.version>1.6.4</kotlinx-coroutines-core.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-    <spring.boot.starter.version>2.2.0.RELEASE</spring.boot.starter.version>
-    <spring-orm.version>5.2.0.RELEASE</spring-orm.version>
-    <spring-kafka.version>2.4.5.RELEASE</spring-kafka.version>
-    <spring-cloud-dependencies.version>Hoxton.RELEASE</spring-cloud-dependencies.version>
-    <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
+    <java.version>17</java.version>
+    <spring.boot.starter.version>2.7.8</spring.boot.starter.version>
+    <spring-kafka.version>3.0.0</spring-kafka.version>
+    <spring-cloud-dependencies.version>2021.0.5</spring-cloud-dependencies.version>
+    <spring-boot-maven-plugin.version>2.7.8</spring-boot-maven-plugin.version>
     <flyway.version>5.2.3</flyway.version>
     <postgres.version>42.2.8</postgres.version>
     <hibernate-types-52.version>2.4.0</hibernate-types-52.version>
     <swagger-annotations.version>1.5.17</swagger-annotations.version>
-    <springfox-swagger2.version>2.7.0</springfox-swagger2.version>
+    <springfox-swagger2.version>3.0.0</springfox-swagger2.version>
     <jackson.core.version>2.10.0</jackson.core.version>
-    <gson.version>2.8.6</gson.version>
-    <groovy.version>2.5.11</groovy.version>
-    <spock.version>1.3-groovy-2.5</spock.version>
-    <swagger-codegen.version>2.4.0</swagger-codegen.version>
+    <gson.version>2.10.1</gson.version>
+    <swagger-codegen.version>2.4.29</swagger-codegen.version>
     <sakila-payment-api-spec.version>1.0-SNAPSHOT</sakila-payment-api-spec.version>
     <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
@@ -70,9 +67,21 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-orm</artifactId>
-      <version>${spring-orm.version}</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+      <version>${spring.boot.starter.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.3</version>
     </dependency>
 
     <dependency>
@@ -120,13 +129,19 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-      <version>${spring.boot.starter.version}</version>
+      <version>3.1.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-      <version>${spring-kafka.version}</version>
+      <version>2.9.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/sakila-payment-service/src/main/java/com/example/sakila/config/CorsConfig.kt
+++ b/sakila-payment-service/src/main/java/com/example/sakila/config/CorsConfig.kt
@@ -12,7 +12,10 @@ class CorsConfig {
   fun corsConfigurer(): WebMvcConfigurer {
     return object: WebMvcConfigurer {
       override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**").allowedMethods("*")
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowedHeaders("*")
+            .allowedMethods("*")
       }
     }
   }

--- a/sakila-payment-service/src/main/resources/application.properties
+++ b/sakila-payment-service/src/main/resources/application.properties
@@ -18,4 +18,4 @@ eureka.client.serviceUrl.defaultZone=${secrets.eureka.server.url}
 
 kafka.group-id=sakila_payment_service
 kafka.broker.url=${secrets.kafka.broker.url}
-    
+

--- a/sakila-store-read-service/Dockerfile
+++ b/sakila-store-read-service/Dockerfile
@@ -1,8 +1,33 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:17.0.6-alpine3.17 as jdk-builder
 
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/sakila-store-service/sakila-store-service.jar"]
+RUN apk add --no-cache binutils
 
-COPY target/lib           /usr/share/sakila-store-service/lib
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules java.base,java.compiler,java.desktop,java.instrument,java.management,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql.rowset,jdk.httpserver,jdk.jfr,jdk.unsupported \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM alpine:3.17
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jdk-builder /jre $JAVA_HOME
+
+RUN adduser --no-create-home -u 1000 -D service
+
+RUN mkdir /usr/share/sakila-store-read-service && \
+    chown -R service /usr/share/sakila-store-read-service
+
+USER 1000
+
+COPY --chown=1000:1000 target/lib /usr/share/sakila-store-read-service/lib
 
 ARG JAR_FILE
-COPY target/${JAR_FILE} /usr/share/sakila-store-service/sakila-store-service.jar
+COPY --chown=1000:1000 target/${JAR_FILE} /usr/share/sakila-store-read-service/sakila-store-read-service.jar
+
+ENTRYPOINT ["/jre/bin/java", "-jar", "/usr/share/sakila-store-read-service/sakila-store-read-service.jar"]
+

--- a/sakila-store-read-service/pom.xml
+++ b/sakila-store-read-service/pom.xml
@@ -13,21 +13,21 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-    <spring.boot.starter.version>2.2.0.RELEASE</spring.boot.starter.version>
-    <spring-kafka.version>2.4.5.RELEASE</spring-kafka.version>
-    <spring-cloud-dependencies.version>Hoxton.RELEASE</spring-cloud-dependencies.version>
-    <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
+    <java.version>17</java.version>
+    <spring.boot.starter.version>2.7.8</spring.boot.starter.version>
+    <spring-kafka.version>3.0.0</spring-kafka.version>
+    <spring-cloud-dependencies.version>2021.0.5</spring-cloud-dependencies.version>
+    <spring-boot-maven-plugin.version>2.7.8</spring-boot-maven-plugin.version>
     <flyway.version>5.2.3</flyway.version>
     <postgres.version>42.2.8</postgres.version>
     <swagger-annotations.version>1.5.17</swagger-annotations.version>
-    <springfox-swagger2.version>2.7.0</springfox-swagger2.version>
+    <springfox-swagger2.version>3.0.0</springfox-swagger2.version>
     <jackson.core.version>2.10.0</jackson.core.version>
-    <gson.version>2.8.6</gson.version>
-    <curator-recipes.version>4.3.0</curator-recipes.version>
+    <gson.version>2.10.1</gson.version>
+    <curator-recipes.version>5.1.0</curator-recipes.version>
     <zookeeper.version>3.6.0</zookeeper.version>
-    <groovy.version>2.5.11</groovy.version>
-    <spock.version>1.3-groovy-2.5</spock.version>
+    <groovy.version>4.0.7</groovy.version>
+    <spock.version>2.4-M1-groovy-4.0</spock.version>
     <swagger-codegen.version>2.4.0</swagger-codegen.version>
     <sakila-store-read-api-spec.version>1.0-SNAPSHOT</sakila-store-read-api-spec.version>
     <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>${spring.boot.starter.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
       <version>${spring.boot.starter.version}</version>
     </dependency>
 
@@ -96,13 +102,19 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-      <version>${spring.boot.starter.version}</version>
+      <version>3.1.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-      <version>${spring-kafka.version}</version>
+      <version>2.9.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -130,8 +142,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-all</artifactId>
+      <scope>test</scope>
       <version>${groovy.version}</version>
       <type>pom</type>
     </dependency>

--- a/sakila-store-read-service/src/main/java/com/example/sakila/config/CorsConfig.java
+++ b/sakila-store-read-service/src/main/java/com/example/sakila/config/CorsConfig.java
@@ -13,7 +13,10 @@ public class CorsConfig {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedMethods("*");
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowedHeaders("*")
+            .allowedMethods("*");
       }
     };
   }

--- a/sakila-store-write-service/Dockerfile
+++ b/sakila-store-write-service/Dockerfile
@@ -1,9 +1,33 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:17.0.6-alpine3.17 as jdk-builder
 
-COPY target/lib         /usr/share/sakila-store-write-service/lib
+RUN apk add --no-cache binutils
+
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules java.base,java.compiler,java.desktop,java.instrument,java.management,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql.rowset,jdk.httpserver,jdk.jfr,jdk.unsupported \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+FROM alpine:3.17
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=jdk-builder /jre $JAVA_HOME
+
+RUN adduser --no-create-home -u 1000 -D service
+
+RUN mkdir /usr/share/sakila-store-write-service && \
+    chown -R service /usr/share/sakila-store-write-service
+
+USER 1000
+
+COPY --chown=1000:1000 target/lib /usr/share/sakila-store-write-service/lib
 
 ARG JAR_FILE
+COPY --chown=1000:1000 target/${JAR_FILE} /usr/share/sakila-store-write-service/sakila-store-write-service.jar
 
-COPY target/${JAR_FILE} /usr/share/sakila-store-write-service/sakila-store-write-service.jar
+ENTRYPOINT ["/jre/bin/java", "-jar", "/usr/share/sakila-store-write-service/sakila-store-write-service.jar"]
 
-ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/sakila-store-write-service/sakila-store-write-service.jar"]

--- a/sakila-store-write-service/pom.xml
+++ b/sakila-store-write-service/pom.xml
@@ -13,21 +13,20 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-    <spring.boot.starter.version>2.2.0.RELEASE</spring.boot.starter.version>
-    <spring-kafka.version>2.4.5.RELEASE</spring-kafka.version>
-    <spring-cloud-dependencies.version>Hoxton.RELEASE</spring-cloud-dependencies.version>
-    <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
+    <java.version>17</java.version>
+    <spring.boot.starter.version>2.7.8</spring.boot.starter.version>
+    <spring-kafka.version>3.0.0</spring-kafka.version>
+    <spring-cloud-dependencies.version>2021.0.5</spring-cloud-dependencies.version>
+    <spring-boot-maven-plugin.version>2.7.8</spring-boot-maven-plugin.version>
     <flyway.version>5.2.3</flyway.version>
     <postgres.version>42.2.8</postgres.version>
     <swagger-annotations.version>1.5.17</swagger-annotations.version>
-    <springfox-swagger2.version>2.7.0</springfox-swagger2.version>
+    <springfox-swagger2.version>3.0.0</springfox-swagger2.version>
     <jackson.core.version>2.10.0</jackson.core.version>
-    <gson.version>2.8.6</gson.version>
-    <groovy.version>2.5.11</groovy.version>
-    <spock.version>1.3-groovy-2.5</spock.version>
+    <spock.version> 2.4-M1-groovy-4.0</spock.version>
+    <gson.version>2.10.1</gson.version>
     <byte-buddy.version>1.10.4</byte-buddy.version>
-    <swagger-codegen.version>2.4.0</swagger-codegen.version>
+    <swagger-codegen.version>2.4.29</swagger-codegen.version>
     <sakila-store-write-api-spec.version>1.0-SNAPSHOT</sakila-store-write-api-spec.version>
     <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
@@ -41,6 +40,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>${spring.boot.starter.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
       <version>${spring.boot.starter.version}</version>
     </dependency>
 
@@ -103,14 +108,20 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-      <version>${spring.boot.starter.version}</version>
+      <version>3.1.4</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka</artifactId>
-      <version>${spring-kafka.version}</version>
-    </dependency>
+  <dependency>
+    <groupId>org.springframework.kafka</groupId>
+    <artifactId>spring-kafka</artifactId>
+    <version>2.9.5</version>
+    <exclusions>
+      <exclusion>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/sakila-store-write-service/src/main/java/com/example/sakila/config/CorsConfig.java
+++ b/sakila-store-write-service/src/main/java/com/example/sakila/config/CorsConfig.java
@@ -13,7 +13,10 @@ public class CorsConfig {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedMethods("*");
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowedHeaders("*")
+            .allowedMethods("*");
       }
     };
   }


### PR DESCRIPTION
Updates all services which use Java, to use Java 17.
Also docker images are updated to use a jlink-ed
JRE based on the modules they need.